### PR TITLE
Ensure that 'Image' class has access to ErrMsgText

### DIFF
--- a/src/image/Image.php
+++ b/src/image/Image.php
@@ -5,6 +5,7 @@ namespace Amenadiel\JpGraph\Image;
 use \Amenadiel\JpGraph\Text\LanguageConv;
 use \Amenadiel\JpGraph\Text\TTF;
 use \Amenadiel\JpGraph\Util;
+use \Amenadiel\JpGraph\Util\ErrMsgText;
 
 //=======================================================================
 // File:        GD_IMAGE.INC.PHP


### PR DESCRIPTION
If there's an error while rendering the image, the `ErrMsgText` class was not being imported, and could not be used.